### PR TITLE
fix: (updatebot) enable single pull request into activiti-dependencies

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -8,3 +8,6 @@ github:
       branch: develop      
     - name: activiti
       branch: develop
+    - name: activiti-dependencies
+      branch: develop
+      useSinglePullRequest: true


### PR DESCRIPTION
We need to push activiti-parent version into activiti-dependencies via single pull request