### PR TITLE
fix: (updatebot) push to all repos via  single pull request 

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -4,10 +4,13 @@ github:
     repositories:
     - name: activiti-api
       branch: develop
+      useSinglePullRequest: true
     - name: activiti-core-common
       branch: develop      
+      useSinglePullRequest: true
     - name: activiti
       branch: develop
+      useSinglePullRequest: true
     - name: activiti-dependencies
       branch: develop
       useSinglePullRequest: true


### PR DESCRIPTION
This PR changes updatebot configuration to push version into all downstream repos via single pull request in order to enforce same parent version dependencies (Part of Activiti/Activiti#2200)